### PR TITLE
[ADD] error handling

### DIFF
--- a/dewildcard
+++ b/dewildcard
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!C:\Python27\python.exe
 #
 # Remove wildcard imports from Python code.
 #
@@ -24,7 +24,7 @@ def import_all_string(module_name, single_line):
         import_line = 'from %s import %%s\n' % module_name
         length = 0
         separator = ', '
-    else:
+    else
         import_line = 'from %s import ( %%s )\n' % module_name
         length = len(import_line) - 5
         separator = ',\n'
@@ -52,15 +52,25 @@ def main():
     import_all_re = re.compile(r'^\s*from\s*([\w.]*)\s*import\s*[*]')
     parsed_lines = []
     with open(args.file) as f:
-        for line in f:
+        for i, line in enumerate(f):
             match = import_all_re.match(line)
             if match:
-                line = import_all_string(match.group(1), args.single_line)
+                try
+                    line = import_all_string(match.group(1), args.single_line)
+                except:
+                    print('ERROR occured while parsing: {}, line {}'.format(args.file, i))
+                    print(' {}'.format(line.splitlines()[0]))
+                    print(' matching group: >>{}<<'.format(match.group(1)))
+                    print('')
+                    raise
+               
             parsed_lines.append(line)
+
+
 
     dest = open(args.file, 'w') if args.write else sys.stdout
     dest.writelines(parsed_lines)
-    dest.close()
+    dest.close(
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Give details to user about the import errors.

In some cases some module cannot be imported, and previous version crashed without any useful information about the problem.

I have added a simple error message on fail.

(The case when it happens example: When the code contains a comment, which contains an import)